### PR TITLE
update model format string to match output from Lobe export.

### DIFF
--- a/src/lobe/ImageModel.py
+++ b/src/lobe/ImageModel.py
@@ -17,7 +17,7 @@ def load_from_signature(signature: Signature) -> ImageModel:
     model_format = signature.format
     if model_format == "tf":
         from .backends import _backend_tf as backend
-    elif model_format == "tflite":
+    elif model_format == "tf_lite":
         from .backends import _backend_tflite as backend
     else:
         raise ValueError("Model is an unsupported format")


### PR DESCRIPTION
The check for backend type is failing due to checking for "tflite" rather than the signature.json value "tf_lite". This PR changes the value check to match the exported signature file for TFLite.