### PR TITLE
Fix super invocations for onnx and tflite backends

### DIFF
--- a/src/lobe/backends/onnx/image_backend.py
+++ b/src/lobe/backends/onnx/image_backend.py
@@ -5,7 +5,7 @@ from ...signature import ImageClassificationSignature
 
 class ONNXImageModel(ONNXModel, ImageBackend):
     def __init__(self, signature: ImageClassificationSignature):
-        super(ONNXModel, self).__init__(signature=signature)
+        super(ONNXImageModel, self).__init__(signature=signature)
 
     def gradcam_plusplus(self, image, label=None):
         super(ONNXImageModel, self).gradcam_plusplus(image=image, label=label)

--- a/src/lobe/backends/tflite/image_backend.py
+++ b/src/lobe/backends/tflite/image_backend.py
@@ -5,7 +5,7 @@ from ...signature import ImageClassificationSignature
 
 class TFLiteImageModel(TFLiteModel, ImageBackend):
     def __init__(self, signature: ImageClassificationSignature):
-        super(TFLiteModel, self).__init__(signature=signature)
+        super(TFLiteImageModel, self).__init__(signature=signature)
 
     def gradcam_plusplus(self, image, label=None):
-        super(TFLiteModel, self).gradcam_plusplus(image=image, label=label)
+        super(TFLiteImageModel, self).gradcam_plusplus(image=image, label=label)


### PR DESCRIPTION
The `super()` calls are using the wrong class name. By doing this,
they're skipping the `__init__()` for the actual super class.

This breaks calling `predict()` because `self.lock` has not been
assigned.

The change for the `tflite` backend has been tested. The change for
`onnx` has not been tested, but seems correct.